### PR TITLE
updated to 0.8.1

### DIFF
--- a/locust-image/requirements.txt
+++ b/locust-image/requirements.txt
@@ -1,2 +1,2 @@
-locustio==0.7.5
-pyzmq==16.0.2
+locustio==0.8.1
+pyzmq==17.0.0


### PR DESCRIPTION
This now works with performance charts in UI. No modifications in official locust helm chart was required except for version of this upgraded container. After merge we will be able to up helm chart for locust. Tested with Kubernetes 1.8.6